### PR TITLE
Add SMPS mode pin to Raspi Pico pins.c

### DIFF
--- a/ports/raspberrypi/boards/raspberry_pi_pico/pins.c
+++ b/ports/raspberrypi/boards/raspberry_pi_pico/pins.c
@@ -24,6 +24,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_GP20), MP_ROM_PTR(&pin_GPIO20) },
     { MP_ROM_QSTR(MP_QSTR_GP21), MP_ROM_PTR(&pin_GPIO21) },
     { MP_ROM_QSTR(MP_QSTR_GP22), MP_ROM_PTR(&pin_GPIO22) },
+    { MP_ROM_QSTR(MP_QSTR_SMPS_MODE), MP_ROM_PTR(&pin_GPIO23) },
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO25) },
     { MP_ROM_QSTR(MP_QSTR_GP25), MP_ROM_PTR(&pin_GPIO25) },
     { MP_ROM_QSTR(MP_QSTR_GP26_A0), MP_ROM_PTR(&pin_GPIO26) },


### PR DESCRIPTION
Add SMPS mode pin to Raspi Pico pins.c; see section "4.3. Using the ADC" of the Pico datasheet for discussion. 

Driving this pin high forces the onboard regulator into a lower noise PWM mode.